### PR TITLE
Refactor antlr4::runtime to just antlr4

### DIFF
--- a/antlr4cpp/antlr/test/test_graph_nodes.cpp
+++ b/antlr4cpp/antlr/test/test_graph_nodes.cpp
@@ -19,7 +19,7 @@
 namespace antlr {
 namespace test {
 
-	using namespace antlr4::runtime::atn;
+	using namespace antlr4::atn;
 
 	namespace {
 

--- a/antlr4cpp/antlr/test/test_interval_set.cpp
+++ b/antlr4cpp/antlr/test/test_interval_set.cpp
@@ -16,8 +16,8 @@
 namespace antlr {
 namespace test {
 
-	using namespace antlr4::runtime;
-	using namespace antlr4::runtime::misc;
+	using namespace antlr4;
+	using namespace antlr4::misc;
 
 	namespace {
 

--- a/antlr4cpp/antlr/test/test_visitor_inheritance.cpp
+++ b/antlr4cpp/antlr/test/test_visitor_inheritance.cpp
@@ -16,9 +16,9 @@
 namespace antlr {
 namespace test {
 
-	using namespace antlr4::runtime;
-	using namespace antlr4::runtime::misc;
-	using namespace antlr4::runtime::tree;
+	using namespace antlr4;
+	using namespace antlr4::misc;
+	using namespace antlr4::tree;
 
 	namespace {
 

--- a/antlr4cpp/antlr/v4/runtime/atn/atn_deserialization_options.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/atn_deserialization_options.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class atn_deserialization_options
@@ -58,6 +57,5 @@ namespace atn {
 		}
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/atn_state.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/atn_state.cpp
@@ -13,7 +13,6 @@
 #endif
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	void atn_state::add_transition(std::shared_ptr<atn::transition> const& transition)
@@ -73,6 +72,5 @@ namespace atn {
 		return std::static_pointer_cast<star_loop_entry_state>(transition(0)->target());
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/atn_state.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/atn_state.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class transition;
@@ -426,14 +425,13 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
 	template<>
-	class hash<antlr4::runtime::atn::atn_state>
+	class hash<antlr4::atn::atn_state>
 	{
-		size_t operator() (antlr4::runtime::atn::atn_state const& state) const
+		size_t operator() (antlr4::atn::atn_state const& state) const
 		{
 			return state.state_number();
 		}

--- a/antlr4cpp/antlr/v4/runtime/atn/atn_type.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/atn_type.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	// Represents the type of recognizer an ATN applies to.
@@ -15,6 +14,5 @@ namespace atn {
 		parser,
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/conflict_information.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/conflict_information.cpp
@@ -4,7 +4,6 @@
 #include <antlr/v4/runtime/atn/conflict_information.hpp>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	bool operator== (conflict_information const& /*x*/, conflict_information const& /*y*/)
@@ -14,11 +13,10 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
-	using namespace antlr4::runtime::atn;
+	using namespace antlr4::atn;
 
 	inline bool hash<conflict_information>::operator()(conflict_information const& /*x*/) const
 	{

--- a/antlr4cpp/antlr/v4/runtime/atn/conflict_information.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/conflict_information.hpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class conflict_information
@@ -41,14 +40,13 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
 	template<>
-	struct hash<antlr4::runtime::atn::conflict_information>
+	struct hash<antlr4::atn::conflict_information>
 	{
-		bool operator() (antlr4::runtime::atn::conflict_information const& x) const;
+		bool operator() (antlr4::atn::conflict_information const& x) const;
 	};
 
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/lexer_action.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/lexer_action.cpp
@@ -6,7 +6,6 @@
 #include <antlr/v4/runtime/atn/lexer_action.hpp>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	namespace {
@@ -80,11 +79,10 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
-	using namespace antlr4::runtime::atn;
+	using namespace antlr4::atn;
 
 	size_t hash<lexer_action>::operator() (lexer_action const& /*action*/) const
 	{

--- a/antlr4cpp/antlr/v4/runtime/atn/lexer_action.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/lexer_action.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class lexer_action
@@ -252,14 +251,13 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
 	template<>
-	struct hash<antlr4::runtime::atn::lexer_action>
+	struct hash<antlr4::atn::lexer_action>
 	{
-		size_t operator() (antlr4::runtime::atn::lexer_action const& action) const;
+		size_t operator() (antlr4::atn::lexer_action const& action) const;
 	};
 
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/lexer_action_executor.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/lexer_action_executor.cpp
@@ -11,10 +11,9 @@
 #include <antlr/v4/runtime/misc/ptr_hash.hpp>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
-	using namespace antlr4::runtime::misc;
+	using namespace antlr4::misc;
 
 	namespace {
 
@@ -95,6 +94,5 @@ namespace atn {
 		return std::equal(x.actions().begin(), x.actions().end(), y.actions().begin(), misc::ptr_equal_to<std::shared_ptr<lexer_action>>());
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/lexer_action_executor.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/lexer_action_executor.hpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class lexer_action;
@@ -37,14 +36,13 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
 	template<>
-	struct hash<antlr4::runtime::atn::lexer_action_executor>
+	struct hash<antlr4::atn::lexer_action_executor>
 	{
-		size_t operator() (antlr4::runtime::atn::lexer_action_executor const& executor) const
+		size_t operator() (antlr4::atn::lexer_action_executor const& executor) const
 		{
 			return executor._hash_code;
 		}

--- a/antlr4cpp/antlr/v4/runtime/atn/prediction_context.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/prediction_context.cpp
@@ -16,7 +16,6 @@
 #endif
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	namespace {
@@ -468,6 +467,5 @@ namespace atn {
 		return context_equal(x, y);
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/prediction_context.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/prediction_context.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 
 namespace antlr4 {
-namespace runtime {
 
 	class rule_context;
 
@@ -90,12 +89,11 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 	template<>
-	struct hash<antlr4::runtime::atn::prediction_context> {
-		size_t operator()(antlr4::runtime::atn::prediction_context const& prediction_context) const
+	struct hash<antlr4::atn::prediction_context> {
+		size_t operator()(antlr4::atn::prediction_context const& prediction_context) const
 		{
 			return static_cast<size_t>(prediction_context.cached_hash_code);
 		}

--- a/antlr4cpp/antlr/v4/runtime/atn/prediction_context_cache.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/prediction_context_cache.cpp
@@ -7,7 +7,6 @@
 #include <antlr/v4/runtime/atn/prediction_context_cache.hpp>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	namespace {
@@ -51,17 +50,16 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
 	template<>
-	struct hash<antlr4::runtime::atn::prediction_context_and_int>
+	struct hash<antlr4::atn::prediction_context_and_int>
 	{
-		size_t operator() (antlr4::runtime::atn::prediction_context_and_int const& value) const
+		size_t operator() (antlr4::atn::prediction_context_and_int const& value) const
 		{
 			size_t hash = 5;
-			hash = 7 * hash + (value.context ? std::hash<antlr4::runtime::atn::prediction_context>()(*value.context) : 0);
+			hash = 7 * hash + (value.context ? std::hash<antlr4::atn::prediction_context>()(*value.context) : 0);
 			hash = 7 * hash + value.value;
 			return hash;
 		}
@@ -70,7 +68,6 @@ namespace std {
 }
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class prediction_context_cache::data
@@ -156,6 +153,5 @@ namespace atn {
 		return result->second;
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/prediction_context_cache.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/prediction_context_cache.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class prediction_context;
@@ -62,14 +61,13 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
 	template<>
-	struct hash<antlr4::runtime::atn::prediction_context_cache::identity_commutative_prediction_context_operands>
+	struct hash<antlr4::atn::prediction_context_cache::identity_commutative_prediction_context_operands>
 	{
-		inline size_t operator()(antlr4::runtime::atn::prediction_context_cache::identity_commutative_prediction_context_operands const& x) const;
+		inline size_t operator()(antlr4::atn::prediction_context_cache::identity_commutative_prediction_context_operands const& x) const;
 	};
 
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/prediction_context_cache.inl
+++ b/antlr4cpp/antlr/v4/runtime/atn/prediction_context_cache.inl
@@ -3,7 +3,6 @@
 #include "prediction_context.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	inline bool operator== (prediction_context_cache::identity_commutative_prediction_context_operands const& x, prediction_context_cache::identity_commutative_prediction_context_operands const& y)
@@ -17,13 +16,12 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
-	inline size_t std::hash<antlr4::runtime::atn::prediction_context_cache::identity_commutative_prediction_context_operands>::operator() (antlr4::runtime::atn::prediction_context_cache::identity_commutative_prediction_context_operands const& x) const
+	inline size_t std::hash<antlr4::atn::prediction_context_cache::identity_commutative_prediction_context_operands>::operator() (antlr4::atn::prediction_context_cache::identity_commutative_prediction_context_operands const& x) const
 	{
-		std::hash<antlr4::runtime::atn::prediction_context> hasher;
+		std::hash<antlr4::atn::prediction_context> hasher;
 		return hasher(*x.x()) ^ hasher(*x.y());
 	}
 

--- a/antlr4cpp/antlr/v4/runtime/atn/semantic_context.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/semantic_context.cpp
@@ -18,10 +18,9 @@
 #endif
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
-	using namespace antlr4::runtime::misc;
+	using namespace antlr4::misc;
 
 	namespace {
 
@@ -232,12 +231,11 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
-	using namespace antlr4::runtime::atn;
-	using namespace antlr4::runtime::misc;
+	using namespace antlr4::atn;
+	using namespace antlr4::misc;
 
 	size_t hash<semantic_context>::operator() (semantic_context const& x) const
 	{

--- a/antlr4cpp/antlr/v4/runtime/atn/semantic_context.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/semantic_context.hpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class semantic_context
@@ -135,14 +134,13 @@ namespace atn {
 
 }
 }
-}
 
 namespace std {
 
 	template<>
-	struct hash<antlr4::runtime::atn::semantic_context>
+	struct hash<antlr4::atn::semantic_context>
 	{
-		size_t operator() (antlr4::runtime::atn::semantic_context const& x) const;
+		size_t operator() (antlr4::atn::semantic_context const& x) const;
 	};
 
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/transition.cpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/transition.cpp
@@ -12,7 +12,6 @@
 #endif
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	bool transition::matches(int32_t symbol, int32_t min_vocab, int32_t max_vocab) const
@@ -60,6 +59,5 @@ namespace atn {
 		}
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/atn/transition.hpp
+++ b/antlr4cpp/antlr/v4/runtime/atn/transition.hpp
@@ -5,7 +5,6 @@
 #include "semantic_context.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace atn {
 
 	class atn_state;
@@ -312,6 +311,5 @@ namespace atn {
 		}
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/dfa/accept_state_information.hpp
+++ b/antlr4cpp/antlr/v4/runtime/dfa/accept_state_information.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 
 namespace antlr4 {
-namespace runtime {
 
 	namespace atn {
 		class lexer_action_executor;
@@ -43,6 +42,5 @@ namespace dfa {
 		}
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/interval_set.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/interval_set.hpp
@@ -10,7 +10,6 @@
 #include "to_string.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<typename _Ty = int32_t, typename _Alloc = std::allocator<std::pair<_Ty, _Ty>>>
@@ -496,6 +495,5 @@ namespace misc {
 		}
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/murmur_hash.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/murmur_hash.hpp
@@ -5,7 +5,6 @@
 #include <functional>
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	struct murmur_hash
@@ -69,6 +68,5 @@ namespace misc {
 		}
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/param_type.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/param_type.hpp
@@ -4,7 +4,6 @@
 #include <functional>
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<typename _Ty>
@@ -17,6 +16,5 @@ namespace misc {
 		typedef typename std::conditional<pass_by_value, _Ty, _Ty const&>::type type;
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/ptr_equal_to.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/ptr_equal_to.hpp
@@ -5,7 +5,6 @@
 #include "param_type.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<typename _Tptr>
@@ -28,6 +27,5 @@ namespace misc {
 		}
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/ptr_hash.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/ptr_hash.hpp
@@ -4,7 +4,6 @@
 #include <functional>
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<typename _Tptr, typename _Hasher = std::hash<std::remove_reference<decltype(*_Tptr())>::type>>
@@ -23,6 +22,5 @@ namespace misc {
 		}
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/to_string.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/to_string.hpp
@@ -4,12 +4,10 @@
 #include "param_type.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<class _Ty>
 	struct to_string;
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/unordered_ptr_map.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/unordered_ptr_map.hpp
@@ -7,12 +7,10 @@
 #include "ptr_hash.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<typename _Tptr, typename _Ty, typename _Hasher = std::hash<std::remove_reference<decltype(*_Tptr())>::type>, typename _Alloc = std::allocator<std::pair<const _Tptr, _Ty>>>
 	using unordered_ptr_map = std::unordered_map<_Tptr, _Ty, ptr_hash<_Tptr, _Hasher>, ptr_equal_to<_Tptr>>;
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/unordered_ptr_set.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/unordered_ptr_set.hpp
@@ -7,12 +7,10 @@
 #include "ptr_hash.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<typename _Tptr, typename _Hasher = std::hash<std::remove_reference<decltype(*_Tptr())>::type>, typename _Alloc = std::allocator<_Tptr>>
 	using unordered_ptr_set = std::unordered_set<_Tptr, ptr_hash<_Tptr, _Hasher>, ptr_equal_to<_Tptr>>;
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/misc/uuid.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/uuid.hpp
@@ -5,7 +5,6 @@
 #include <functional>
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	class uuid
@@ -103,13 +102,12 @@ namespace misc {
 
 }
 }
-}
 
 namespace std {
 	template<>
-	struct hash<antlr4::runtime::misc::uuid>
+	struct hash<antlr4::misc::uuid>
 	{
-		size_t operator() (antlr4::runtime::misc::uuid const& value) const
+		size_t operator() (antlr4::misc::uuid const& value) const
 		{
 			auto result = value._a
 				^ ((static_cast<int32_t>(value._b) << 16) | static_cast<int32_t>(static_cast<uint16_t>(value._c)))

--- a/antlr4cpp/antlr/v4/runtime/misc/visitor.hpp
+++ b/antlr4cpp/antlr/v4/runtime/misc/visitor.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 namespace antlr4 {
-namespace runtime {
 namespace misc {
 
 	template<typename... _Types>
@@ -36,6 +35,5 @@ namespace misc {
 		virtual void accept(visitor<_Types...>& visitor) const = 0;
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/token.hpp
+++ b/antlr4cpp/antlr/v4/runtime/token.hpp
@@ -4,7 +4,6 @@
 #include <cstdint>
 
 namespace antlr4 {
-namespace runtime {
 
 	class token
 	{
@@ -13,5 +12,4 @@ namespace runtime {
 		static const int32_t eof = -1;
 	};
 
-}
 }

--- a/antlr4cpp/antlr/v4/runtime/tree/parse_tree.cpp
+++ b/antlr4cpp/antlr/v4/runtime/tree/parse_tree.cpp
@@ -5,7 +5,6 @@
 #include "parse_tree_visitor.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace tree {
 
 	std::wstring rule_node::text() const
@@ -33,6 +32,5 @@ namespace tree {
 		visitor.visit(*this);
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/tree/parse_tree.hpp
+++ b/antlr4cpp/antlr/v4/runtime/tree/parse_tree.hpp
@@ -6,7 +6,6 @@
 #include "../misc/visitor.hpp"
 
 namespace antlr4 {
-namespace runtime {
 
 	class token;
 
@@ -145,7 +144,7 @@ namespace tree {
 	class error_node : public terminal_node
 	{
 	public:
-		error_node(std::shared_ptr<runtime::token> const& token, std::shared_ptr<rule_node> const& parent)
+		error_node(std::shared_ptr<antlr4::token> const& token, std::shared_ptr<rule_node> const& parent)
 			: terminal_node(token, parent)
 		{
 		}
@@ -160,6 +159,5 @@ namespace tree {
 		virtual void accept(parse_tree_visitor& visitor) const override;
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/tree/parse_tree_listener.hpp
+++ b/antlr4cpp/antlr/v4/runtime/tree/parse_tree_listener.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 namespace antlr4 {
-namespace runtime {
 namespace tree {
 
 	class error_node;
@@ -22,6 +21,5 @@ namespace tree {
 		virtual void visit(error_node const& node) = 0;
 	};
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/tree/parse_tree_visitor.hpp
+++ b/antlr4cpp/antlr/v4/runtime/tree/parse_tree_visitor.hpp
@@ -5,7 +5,6 @@
 #include "../misc/visitor.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace tree {
 
 	class error_node;
@@ -57,7 +56,6 @@ namespace tree {
 		virtual bool should_visit_next_child(rule_node const& node, result_param_type current_result);
 	};
 
-}
 }
 }
 

--- a/antlr4cpp/antlr/v4/runtime/tree/parse_tree_visitor.inl
+++ b/antlr4cpp/antlr/v4/runtime/tree/parse_tree_visitor.inl
@@ -4,7 +4,6 @@
 #include "parse_tree_visitor.hpp"
 
 namespace antlr4 {
-namespace runtime {
 namespace tree {
 
 	template<typename _TResult>
@@ -63,6 +62,5 @@ namespace tree {
 		return true;
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/tree/parse_tree_walker.cpp
+++ b/antlr4cpp/antlr/v4/runtime/tree/parse_tree_walker.cpp
@@ -14,7 +14,6 @@
 #endif
 
 namespace antlr4 {
-namespace runtime {
 namespace tree {
 
 	namespace {
@@ -86,6 +85,5 @@ namespace tree {
 		listener.exit_node(tree);
 	}
 
-}
 }
 }

--- a/antlr4cpp/antlr/v4/runtime/tree/parse_tree_walker.hpp
+++ b/antlr4cpp/antlr/v4/runtime/tree/parse_tree_walker.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 namespace antlr4 {
-namespace runtime {
 namespace tree {
 
 	class error_node;
@@ -39,6 +38,5 @@ namespace tree {
 		virtual void exit_rule(parse_tree_listener& listener, rule_node const& tree);
 	};
 
-}
 }
 }


### PR DESCRIPTION
This simplifies the namespaces for the project, which improves the experience for both contributors and users. Note that I did not move any files around at this point, because that should be a coordinated effort with anyone else already working on implementing parts of the project.
