### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # Temporary and per-user files created by Visual Studio
 *.opensdf
 *.sdf
-*.sln.ide/
 *.suo
 *.vcxproj.user
 ipch/
+.vs/
 
 # Build output
 Debug/
+Release/


### PR DESCRIPTION
- Removed ***.sln.ide/** (Only created by early pre-release builds of Visual Studio 2015)
- Added **.vs/** (created by VS 2015)
- Added **Release/** (output folder)
